### PR TITLE
Block empty statement when using -e flag

### DIFF
--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -29,23 +29,27 @@ func NewRootCmd() *cobra.Command {
 			}
 			defer db.Close()
 
-			if len(rootArgs.statements) == 0 {
-				shellConfig := lib.ShellConfig{
-					InF:         cmd.InOrStdin(),
-					OutF:        cmd.OutOrStdout(),
-					ErrF:        cmd.ErrOrStderr(),
-					HistoryFile: fmt.Sprintf("%s/.libsql_shell_history", os.Getenv("HOME")),
+			if cmd.Flag("exec").Changed {
+				if len(rootArgs.statements) == 0 {
+					return fmt.Errorf("no SQL command to execute")
 				}
 
-				return db.RunShell(&shellConfig)
+				results, err := db.ExecuteStatements(rootArgs.statements)
+				if err != nil {
+					return err
+				}
+				lib.PrintStatementsResults(results, cmd.OutOrStdout(), false)
+				return nil
 			}
 
-			results, err := db.ExecuteStatements(rootArgs.statements)
-			if err != nil {
-				return err
+			shellConfig := lib.ShellConfig{
+				InF:         cmd.InOrStdin(),
+				OutF:        cmd.OutOrStdout(),
+				ErrF:        cmd.ErrOrStderr(),
+				HistoryFile: fmt.Sprintf("%s/.libsql_shell_history", os.Getenv("HOME")),
 			}
-			lib.PrintStatementsResults(results, cmd.OutOrStdout(), false)
-			return nil
+
+			return db.RunShell(&shellConfig)
 		},
 	}
 

--- a/testing/root_command_flags_test.go
+++ b/testing/root_command_flags_test.go
@@ -29,3 +29,11 @@ func TestRootCommandFlags_WhenDbIsMissing_ExpectErrorReturned(t *testing.T) {
 
 	c.Assert(err.Error(), qt.Equals, `accepts 1 arg(s), received 0`)
 }
+
+func TestRootCommandFlags_GivenEmptyStatements_ExpectErrorReturned(t *testing.T) {
+	tc := utils.NewTestContext(t)
+
+	_, err := tc.Execute("")
+
+	tc.Assert(err.Error(), qt.IsNotNil)
+}


### PR DESCRIPTION
## Description

- Don't execute empty statements and print the same message as iku-turso-shell
- Add test

## Related Issues

- Closes #32

## Visual reference

![image](https://user-images.githubusercontent.com/35314270/221591748-69805eee-47da-423f-aaf3-50be97d857b7.png)
