### PR TITLE
Stop printing too many errors when using -e flag

### DIFF
--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -58,7 +58,6 @@ func Init() {
 	var rootCmd *cobra.Command = NewRootCmd()
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Description

Stop printing too many errors when using -e flag

## Related Issues

- Closes #31

## Visual reference

Before:

![image](https://user-images.githubusercontent.com/35314270/221644728-eb0e3520-70c1-4280-9977-839b8bc5051d.png)

Now:

![image](https://user-images.githubusercontent.com/35314270/221644643-99027662-3b85-4bc6-a1a3-8425f8f2b7a1.png)

