### PR TITLE
Improve transaction error when using turso

### DIFF
--- a/src/lib/errors.go
+++ b/src/lib/errors.go
@@ -1,0 +1,7 @@
+package lib
+
+type TransactionNotSupportedError struct{}
+
+func (e *TransactionNotSupportedError) Error() string {
+	return "transactions are only supported in the shell using semicolons to separate each statement.\nFor example: \"BEGIN; [your SQL statements]; END\""
+}

--- a/src/lib/lib.go
+++ b/src/lib/lib.go
@@ -59,6 +59,9 @@ func (db *Db) ExecuteStatements(statementsString string) (string, error) {
 	for _, statement := range statements {
 		statementResult, err := db.executeStatement(statement)
 		if err != nil {
+			if strings.Contains(err.Error(), "interactive transaction not allowed in HTTP queries") {
+				return "", &TransactionNotSupportedError{}
+			}
 			return "", err
 		}
 		if strings.TrimSpace(statementResult) != "" {


### PR DESCRIPTION
## Description

Transactions are only supported in turso if you use semicolons to separate each statement. So improve the error message with an example of how to use it

## Related Issues

- Closes #33

## Visual reference

![image](https://user-images.githubusercontent.com/35314270/221922176-9fb0b8a1-6b40-4219-ae1b-5ce0233fd25a.png)
