### PR TITLE
change(lib/output): print blobs uppercased and appending 0x before he…

### DIFF
--- a/src/lib/output.go
+++ b/src/lib/output.go
@@ -160,7 +160,7 @@ func decodeBase64ToHex(base64String string) (string, error) {
 }
 
 func formatBytes(bytes []byte) string {
-	return fmt.Sprintf("%x", bytes)
+	return fmt.Sprintf("0x%X", bytes)
 }
 
 func formatRawTypes(value reflect.Value) (string, error) {

--- a/testing/root_command_exec_test.go
+++ b/testing/root_command_exec_test.go
@@ -139,7 +139,7 @@ func (s *RootCommandExecSuite) TestRootCommandExec_GivenTableCotainingBlobField_
 	s.tc.Assert(err, qt.IsNil)
 	s.tc.Assert(errS, qt.Equals, "")
 
-	s.tc.Assert(outS, qt.Equals, utils.GetPrintTableOutput([]string{"T", "I", "R", "B"}, [][]string{{"text", "99", "3.14", "0123456789abcdef"}}))
+	s.tc.Assert(outS, qt.Equals, utils.GetPrintTableOutput([]string{"T", "I", "R", "B"}, [][]string{{"text", "99", "3.14", "0x0123456789ABCDEF"}}))
 }
 
 func TestRootCommandExecSuite_WhenDbIsSQLite(t *testing.T) {


### PR DESCRIPTION
## Description

Changing way we print blob/hexadecimal values

## Visual reference

Before
![image](https://user-images.githubusercontent.com/13895110/223188915-f0e533ba-a0e7-4b05-8215-973f79231d05.png)

After
![image](https://user-images.githubusercontent.com/13895110/223188666-24a1e9c7-c021-4efe-aa27-122cf8c8b13f.png)
