### PR TITLE
fix: rename module

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -7,8 +7,8 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/spf13/cobra"
 
-	"github.com/chiselstrike/libsql-shell/pkg/libsql"
-	"github.com/chiselstrike/libsql-shell/shell"
+	"github.com/libsql/libsql-shell-go/pkg/libsql"
+	"github.com/libsql/libsql-shell-go/shell"
 )
 
 type RootArgs struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chiselstrike/libsql-shell
+module github.com/libsql/libsql-shell-go
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/chiselstrike/libsql-shell/cmd"
+	"github.com/libsql/libsql-shell-go/cmd"
 )
 
 func main() {

--- a/pkg/libsql/output_test.go
+++ b/pkg/libsql/output_test.go
@@ -3,8 +3,8 @@ package libsql_test
 import (
 	"testing"
 
-	"github.com/chiselstrike/libsql-shell/test/utils"
 	qt "github.com/frankban/quicktest"
+	"github.com/libsql/libsql-shell-go/test/utils"
 )
 
 func TestGetTableOutput_GivenHeaderWithoutData_ExpectTableHasJustHeader(t *testing.T) {

--- a/shell/databaseRootCommand.go
+++ b/shell/databaseRootCommand.go
@@ -7,7 +7,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/spf13/cobra"
 
-	"github.com/chiselstrike/libsql-shell/pkg/libsql"
+	"github.com/libsql/libsql-shell-go/pkg/libsql"
 )
 
 type dbCtx struct{}

--- a/shell/history.go
+++ b/shell/history.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/chiselstrike/libsql-shell/pkg/libsql"
+	"github.com/libsql/libsql-shell-go/pkg/libsql"
 )
 
 type HistoryMode int64

--- a/shell/history_test.go
+++ b/shell/history_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/chiselstrike/libsql-shell/shell"
 	qt "github.com/frankban/quicktest"
+	"github.com/libsql/libsql-shell-go/shell"
 )
 
 const historyName = "libsql"

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -6,9 +6,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/chiselstrike/libsql-shell/pkg/libsql"
 	"github.com/chzyer/readline"
 	"github.com/fatih/color"
+	"github.com/libsql/libsql-shell-go/pkg/libsql"
 	"github.com/spf13/cobra"
 )
 

--- a/test/db_root_command_shell_test.go
+++ b/test/db_root_command_shell_test.go
@@ -6,7 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/chiselstrike/libsql-shell/test/utils"
+	"github.com/libsql/libsql-shell-go/test/utils"
 )
 
 type DBRootCommandShellSuite struct {

--- a/test/root_command_exec_test.go
+++ b/test/root_command_exec_test.go
@@ -7,7 +7,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/chiselstrike/libsql-shell/test/utils"
+	"github.com/libsql/libsql-shell-go/test/utils"
 )
 
 type RootCommandExecSuite struct {

--- a/test/root_command_flags_test.go
+++ b/test/root_command_flags_test.go
@@ -5,8 +5,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/chiselstrike/libsql-shell/cmd"
-	"github.com/chiselstrike/libsql-shell/test/utils"
+	"github.com/libsql/libsql-shell-go/cmd"
+	"github.com/libsql/libsql-shell-go/test/utils"
 )
 
 func TestRootCommandFlags_WhenAllFlagsAreProvided_ExpectSQLStatementsExecutedWithoutError(t *testing.T) {

--- a/test/root_command_shell_test.go
+++ b/test/root_command_shell_test.go
@@ -6,7 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/chiselstrike/libsql-shell/test/utils"
+	"github.com/libsql/libsql-shell-go/test/utils"
 )
 
 type RootCommandShellSuite struct {

--- a/test/utils/db_test_context.go
+++ b/test/utils/db_test_context.go
@@ -8,7 +8,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/chiselstrike/libsql-shell/cmd"
+	"github.com/libsql/libsql-shell-go/cmd"
 )
 
 type DbTestContext struct {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chiselstrike/libsql-shell/pkg/libsql"
+	"github.com/libsql/libsql-shell-go/pkg/libsql"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
## Description

rename module to `github.com/libsql/libsql-shell-go`
