### PR TITLE
fix(shell/history): use host name instead of user to set history name

### DIFF
--- a/internal/shell/history.go
+++ b/internal/shell/history.go
@@ -18,8 +18,8 @@ func GetHistoryFileBasedOnMode(dbPath string, mode enums.HistoryMode, historyNam
 	case enums.LocalHistory:
 		return sharedHistoryFileName
 	case enums.PerDatabaseHistory:
-		if parsedName, err := parseNameFromDbPath(dbPath); err == nil && parsedName != "" {
-			return getHistoryFileFullPath(historyName, getHistoryFileName(parsedName))
+		if host, err := getHostFromDbPath(dbPath); err == nil && host != "" {
+			return getHistoryFileFullPath(historyName, getHistoryFileName(host))
 		}
 	}
 
@@ -40,16 +40,16 @@ func getHistoryFolderPath(historyName string) string {
 	return path
 }
 
-func parseNameFromDbPath(dbPath string) (string, error) {
+func getHostFromDbPath(dbPath string) (string, error) {
 	if db.IsUrl(dbPath) {
 		url, err := url.Parse(dbPath)
 		if err != nil {
 			return "", err
 		}
-		if url.User == nil {
-			return "", &shellerrors.UrlDoesNotContainUserError{}
+		if url.Host == "" {
+			return "", &shellerrors.UrlDoesNotContainHostError{}
 		}
-		return url.User.String(), nil
+		return url.Host, nil
 	}
 
 	return getFileNameWithoutExtension(dbPath), nil

--- a/internal/shell/history_test.go
+++ b/internal/shell/history_test.go
@@ -78,21 +78,51 @@ func TestGetHistoryFileBasedOnMode_GivenPerDatabaseHistory_WhenPathIsEmpty_Expec
 	c.Assert(result, qt.Equals, expectedPath)
 }
 
-func TestGetHistoryFileBasedOnMode_GivenPerDatabaseHistory_WhenPathIsHttpUrl_ExpectSpecificGlobalHistory(t *testing.T) {
+func TestGetHistoryFileBasedOnMode_GivenPerDatabaseHistory_WhenPathIsHttpUrlWithUser_ExpectSpecificGlobalHistory(t *testing.T) {
 	c := qt.New(t)
 
-	dbPath := "https://username:password@company.turso.io"
-	expectedPath := getExpectedHistoryFullPath("username:password")
+	dbPath := "https://username:password@database-username.turso.io"
+	expectedPath := getExpectedHistoryFullPath("database-username.turso.io")
 	result := shell.GetHistoryFileBasedOnMode(dbPath, enums.PerDatabaseHistory, historyName)
 
 	c.Assert(result, qt.Equals, expectedPath)
 }
 
-func TestGetHistoryFileBasedOnMode_GivenPerDatabaseHistory_WhenPathIsHttpUrlWithoutUser_ExpectSharedGlobalHistory(t *testing.T) {
+func TestGetHistoryFileBasedOnMode_GivenPerDatabaseHistory_WhenPathIsHttpUrlWithoutUser_ExpectSpecificGlobalHistory(t *testing.T) {
 	c := qt.New(t)
 
-	dbPath := "https://company.turso.io"
-	expectedPath := getExpectedHistoryFullPath(historyName)
+	dbPath := "https://database-username.turso.io"
+	expectedPath := getExpectedHistoryFullPath("database-username.turso.io")
+	result := shell.GetHistoryFileBasedOnMode(dbPath, enums.PerDatabaseHistory, historyName)
+
+	c.Assert(result, qt.Equals, expectedPath)
+}
+
+func TestGetHistoryFileBasedOnMode_GivenPerDatabaseHistory_WhenPathIsLibsqlUrl_ExpectSpecificGlobalHistory(t *testing.T) {
+	c := qt.New(t)
+
+	dbPath := "libsql://database-username.turso.io/?jwt=some_token"
+	expectedPath := getExpectedHistoryFullPath("database-username.turso.io")
+	result := shell.GetHistoryFileBasedOnMode(dbPath, enums.PerDatabaseHistory, historyName)
+
+	c.Assert(result, qt.Equals, expectedPath)
+}
+
+func TestGetHistoryFileBasedOnMode_GivenPerDatabaseHistory_WhenPathIsWssUrl_ExpectSpecificGlobalHistory(t *testing.T) {
+	c := qt.New(t)
+
+	dbPath := "wss://database-username.turso.io/?jwt=some_token"
+	expectedPath := getExpectedHistoryFullPath("database-username.turso.io")
+	result := shell.GetHistoryFileBasedOnMode(dbPath, enums.PerDatabaseHistory, historyName)
+
+	c.Assert(result, qt.Equals, expectedPath)
+}
+
+func TestGetHistoryFileBasedOnMode_GivenPerDatabaseHistory_WhenPathIsWsUrl_ExpectSpecificGlobalHistory(t *testing.T) {
+	c := qt.New(t)
+
+	dbPath := "ws://database-username.turso.io/?jwt=some_token"
+	expectedPath := getExpectedHistoryFullPath("database-username.turso.io")
 	result := shell.GetHistoryFileBasedOnMode(dbPath, enums.PerDatabaseHistory, historyName)
 
 	c.Assert(result, qt.Equals, expectedPath)

--- a/pkg/shell/shellerrors/errors.go
+++ b/pkg/shell/shellerrors/errors.go
@@ -19,13 +19,13 @@ func (e *TransactionNotSupportedError) userError() string {
 	return "transactions are only supported in the shell using semicolons to separate each statement.\nFor example: \"BEGIN; [your SQL statements]; END\""
 }
 
-type UrlDoesNotContainUserError struct{}
+type UrlDoesNotContainHostError struct{}
 
-func (e *UrlDoesNotContainUserError) Error() string {
+func (e *UrlDoesNotContainHostError) Error() string {
 	return e.userError()
 }
-func (e *UrlDoesNotContainUserError) userError() string {
-	return "url does not contain user"
+func (e *UrlDoesNotContainHostError) userError() string {
+	return "url does not contain host"
 }
 
 type InvalidTursoProtocolError struct{}


### PR DESCRIPTION
## Description

Fix history per database when receiving database URL (in practice is always this way). We were using URL's user instead of the database itself (URL's host)
