### PR TITLE
RunShellLine doen't run test connection

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -65,15 +65,10 @@ func NewDb(dbPath string) (*Db, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	if err = db.testConnection(); err != nil {
-		return nil, err
-	}
-
 	return &db, nil
 }
 
-func (db *Db) testConnection() error {
+func (db *Db) TestConnection() error {
 	_, err := db.sqlDb.Exec("SELECT 1;")
 	if err != nil {
 		return fmt.Errorf("failed to connect to database")

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -25,6 +25,9 @@ func RunShell(config ShellConfig) error {
 	if err != nil {
 		return err
 	}
+	if err := db.TestConnection(); err != nil {
+		db = nil
+	}
 	defer db.Close()
 
 	if config.AfterDbConnectionCallback != nil {

--- a/test/utils/db_test_context.go
+++ b/test/utils/db_test_context.go
@@ -28,6 +28,9 @@ func NewTestContext(t *testing.T, dbPath string) *DbTestContext {
 	if err != nil {
 		t.Fatalf("Fail to create new db")
 	}
+	if err := db.TestConnection(); err != nil {
+		db = nil
+	}
 
 	return &DbTestContext{T: t, C: qt.New(t), dbPath: dbPath, db: db}
 }


### PR DESCRIPTION
## Description

shell.RunShellLine currently checks db connection for every line it runs, doubling roundtrip costs in so doing. This PR removes this check for RunShellLine while leaving the check for batch operations.

## Related Issues

- Closes #93 
