### PR TITLE
Revert "Batch queries when using HTTP client"

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -131,11 +131,6 @@ func (db *Db) ExecuteStatements(statementsString string) (StatementsResult, erro
 }
 
 func (db *Db) executeQueriesAndPopulateChannel(queries []string, statementResultCh chan StatementResult) {
-	if strings.HasPrefix(db.urlScheme, "http") {
-		query := strings.Join(queries, "; ")
-		db.executeQuery(query, statementResultCh)
-		return
-	}
 	for _, query := range queries {
 		if shouldContinue := db.executeQuery(query, statementResultCh); !shouldContinue {
 			return


### PR DESCRIPTION
Reverts tursodatabase/libsql-shell-go#168

It is a no op. We don't split statements for http/https -> https://github.com/tursodatabase/libsql-shell-go/blob/main/internal/db/db.go#L185